### PR TITLE
fix: poner index.html en /root

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["develop"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Hace falta poner `index.html` en el `/root`, para que se pueda detectar en pages.

```
on:
  # Runs on pushes targeting the default branch
  push:
    branches: ["main"]
```
Esta parte sirve para que _pages_ actualice solo cuando se haga un _push_ sobre esta rama.

<img width="600" height="auto" alt="image" src="https://github.com/user-attachments/assets/436b1066-c3d8-4476-ba6c-1ae13412c401" />

@SelamBel la configuración al final hay que dejarla en `Deploy from a Branch`, déjala en `/root` y se renderizará _pages_.

>[!WARNING]
> No olvides que hay que borrar el workflow de [Deploy static content to Pages](https://github.com/SelamBel/Digitalizacion-PartesTrabajo/actions/workflows/static.yml)

>[!IMPORTANT]
> Haz el pr a `main`, para que se actualice _pages_